### PR TITLE
Allow specifying a pattern to match against container names

### DIFF
--- a/bin/dlt
+++ b/bin/dlt
@@ -33,6 +33,7 @@ if (options.help) {
 function go() {
   logAllContainers({
     tail: options.n,
-    useColor: options.color
+    useColor: options.color,
+    pattern: options.argv.remain[0]
   })
 }

--- a/src/log-all-containers.js
+++ b/src/log-all-containers.js
@@ -4,15 +4,18 @@ const containerLogs = require('./container-logs')
 
 let watchingContainers = {}
 
-module.exports = function logAllContainers({ tail, useColor }) {
+module.exports = function logAllContainers({ tail, useColor, pattern }) {
+  let patternRegex = pattern ? new RegExp(pattern) : new RegExp()
+
   docker.listContainers({ all: false }, (err, containers) => {
     if (containers) {
       containers.map(container => {
-        if (!watchingContainers[container.Id]) {
+        let containerName = container.Names[0].replace(/^\//, '')
+        if (!watchingContainers[container.Id] && patternRegex.test(containerName)) {
           watchingContainers[container.Id] = true
           containerLogs(
             docker.getContainer(container.Id),
-            container.Names[0].replace(/^\//, ''),
+            containerName,
             { tail, useColor }
           )
         }


### PR DESCRIPTION
This allows you to narrow down which containers to tail.

`dlt zen -n 15` will only tail the containers that have `zen` in their name.